### PR TITLE
Backport fix for CVE-2024-29857

### DIFF
--- a/core/src/main/java/org/bouncycastle/math/ec/ECCurve.java
+++ b/core/src/main/java/org/bouncycastle/math/ec/ECCurve.java
@@ -12,6 +12,7 @@ import org.bouncycastle.math.field.FiniteFields;
 import org.bouncycastle.math.raw.Nat;
 import org.bouncycastle.util.BigIntegers;
 import org.bouncycastle.util.Integers;
+import org.bouncycastle.util.Properties;
 
 /**
  * base class for an elliptic curve
@@ -797,10 +798,14 @@ public abstract class ECCurve
 
         private static FiniteField buildField(int m, int k1, int k2, int k3)
         {
-            if (k1 == 0)
+            if (m > Properties.asInteger("org.bouncycastle.ec.max_f2m_field_size", 1142))  // twice 571
             {
-                throw new IllegalArgumentException("k1 must be > 0");
+                throw new IllegalArgumentException("field size out of range: " + m);
             }
+
+            int[] exponents = (k2 | k3) == 0
+                ? new int[]{ 0, k1, m }
+                : new int[]{ 0, k1, k2, k3, m };
 
             if (k2 == 0)
             {

--- a/core/src/main/java/org/bouncycastle/math/ec/ECCurve.java
+++ b/core/src/main/java/org/bouncycastle/math/ec/ECCurve.java
@@ -803,10 +803,6 @@ public abstract class ECCurve
                 throw new IllegalArgumentException("field size out of range: " + m);
             }
 
-            int[] exponents = (k2 | k3) == 0
-                ? new int[]{ 0, k1, m }
-                : new int[]{ 0, k1, k2, k3, m };
-
             if (k2 == 0)
             {
                 if (k3 != 0)

--- a/core/src/main/java/org/bouncycastle/util/Properties.java
+++ b/core/src/main/java/org/bouncycastle/util/Properties.java
@@ -115,6 +115,31 @@ public class Properties
         return false;
     }
 
+    /**
+     * Return propertyName as an integer, defaultValue used if not defined.
+     *
+     * @param propertyName name of property.
+     * @param defaultValue integer to return if property not defined.
+     * @return value of property, or default if not found, as an int.
+     */
+    public static int asInteger(String propertyName, int defaultValue)
+    {
+        String p = getPropertyValue(propertyName);
+
+        if (p != null)
+        {
+            return Integer.parseInt(p);
+        }
+
+        return defaultValue;
+    }
+
+    /**
+     * Return propertyName as a BigInteger.
+     *
+     * @param propertyName name of property.
+     * @return value of property as a BigInteger, null if not defined.
+     */
     public static BigInteger asBigInteger(String propertyName)
     {
         String p = getPropertyValue(propertyName);
@@ -145,6 +170,13 @@ public class Properties
         return Collections.unmodifiableSet(set);
     }
 
+    /**
+     * Return the String value of the property propertyName. Property valuation
+     * starts with java.security, then thread local, then system properties.
+     *
+     * @param propertyName name of property.
+     * @return value of property as a String, null if not defined.
+     */
     public static String getPropertyValue(final String propertyName)
     {
         String val = (String)AccessController.doPrivileged(new PrivilegedAction()

--- a/core/src/test/java/org/bouncycastle/math/ec/test/ECPointTest.java
+++ b/core/src/test/java/org/bouncycastle/math/ec/test/ECPointTest.java
@@ -197,6 +197,25 @@ public class ECPointTest extends TestCase
         }
     }
 
+    public void testLargeMInF2m()
+    {
+        int m = 2048;
+        int k1 = 1;
+        BigInteger aTpb = new BigInteger("1000", 2);
+        BigInteger bTpb = new BigInteger("1001", 2);
+        BigInteger n = new BigInteger("23");
+        BigInteger h = new BigInteger("1");
+
+        try
+        {
+            ECCurve.F2m curve = new ECCurve.F2m(m, k1, aTpb, bTpb, n, h);
+        }
+        catch (IllegalArgumentException e)
+        {
+            assertEquals("field size out of range: 2048", e.getMessage());
+        }
+    }
+
     /**
      * Calls <code>implTestAdd()</code> for <code>Fp</code> and
      * <code>F2m</code>.


### PR DESCRIPTION
CVE-2024-29857 : original commit id fee80dd230e7fba132d03a34f1dd1d6aae0d0281
1. Fixed lack of a maximum bounds check in the F2m curve constructor, leading to excessive CPU consumption.
2. Added asInteger() in Properties class.
