### PR TITLE
Backport fix for CVE 2023 33201

### DIFF
--- a/prov/src/main/java/org/bouncycastle/jce/provider/X509LDAPCertStoreSpi.java
+++ b/prov/src/main/java/org/bouncycastle/jce/provider/X509LDAPCertStoreSpi.java
@@ -395,6 +395,64 @@ public class X509LDAPCertStoreSpi
 
         return crlSet;
     }
+    private static String[] FILTER_ESCAPE_TABLE = new String['\\' + 1];
+
+
+    static
+    {
+
+        // Filter encoding table -------------------------------------
+
+        // fill with char itself
+        for (char c = 0; c < FILTER_ESCAPE_TABLE.length; c++)
+        {
+            FILTER_ESCAPE_TABLE[c] = String.valueOf(c);
+        }
+
+        // escapes (RFC2254)
+        FILTER_ESCAPE_TABLE['*'] = "\\2a";
+        FILTER_ESCAPE_TABLE['('] = "\\28";
+        FILTER_ESCAPE_TABLE[')'] = "\\29";
+        FILTER_ESCAPE_TABLE['\\'] = "\\5c";
+        FILTER_ESCAPE_TABLE[0] = "\\00";
+
+    }
+
+    /**
+     * Escape a value for use in a filter.
+     * @param value the value to escape.
+     * @return a properly escaped representation of the supplied value.
+     */
+    private String filterEncode(String value)
+    {
+        if (value == null)
+        {
+            return null;
+        }
+
+        // make buffer roomy
+        StringBuilder encodedValue = new StringBuilder(value.length() * 2);
+
+        int length = value.length();
+
+        for (int i = 0; i < length; i++)
+        {
+
+            char c = value.charAt(i);
+
+            if (c < FILTER_ESCAPE_TABLE.length)
+            {
+                encodedValue.append(FILTER_ESCAPE_TABLE[c]);
+            }
+            else
+            {
+                // default: add the char
+                encodedValue.append(c);
+            }
+        }
+
+        return encodedValue.toString();
+    }
 
     /**
      * Returns a Set of byte arrays with the certificate or CRL encodings.
@@ -408,7 +466,8 @@ public class X509LDAPCertStoreSpi
     private Set search(String attributeName, String attributeValue,
                        String[] attrs) throws CertStoreException
     {
-        String filter = attributeName + "=" + attributeValue;
+        String filter = attributeName + "=" + filterEncode(attributeValue);
+        System.out.println(filter);
         if (attributeName == null)
         {
             filter = null;

--- a/prov/src/main/java/org/bouncycastle/jce/provider/X509LDAPCertStoreSpi.java
+++ b/prov/src/main/java/org/bouncycastle/jce/provider/X509LDAPCertStoreSpi.java
@@ -467,7 +467,6 @@ public class X509LDAPCertStoreSpi
                        String[] attrs) throws CertStoreException
     {
         String filter = attributeName + "=" + filterEncode(attributeValue);
-        System.out.println(filter);
         if (attributeName == null)
         {
             filter = null;


### PR DESCRIPTION
    1. Added filter encode to LDAP search, original commit id e8c409a8389c815ea3fda5e8b94c92fdfe583bcc
    2. Fixed stylecheck errors post cherry-pick.
    3. Added Unit tests.
