### PR TITLE
Backport fix for CVE-2024-30171

### DIFF
--- a/core/src/main/java/org/bouncycastle/crypto/tls/TlsRsaKeyExchange.java
+++ b/core/src/main/java/org/bouncycastle/crypto/tls/TlsRsaKeyExchange.java
@@ -1,0 +1,66 @@
+package org.bouncycastle.crypto.tls;
+
+import java.security.SecureRandom;
+
+import org.bouncycastle.crypto.encodings.PKCS1Encoding;
+import org.bouncycastle.crypto.engines.RSABlindedEngine;
+import org.bouncycastle.crypto.params.ParametersWithRandom;
+import org.bouncycastle.crypto.params.RSAKeyParameters;
+import org.bouncycastle.util.Arrays;
+import org.bouncycastle.util.Pack;
+
+public abstract class TlsRsaKeyExchange
+{
+    private TlsRsaKeyExchange()
+    {
+    }
+
+    public static byte[] decryptPreMasterSecret(byte[] encryptedPreMasterSecret, RSAKeyParameters privateKey,
+        int protocolVersion, SecureRandom secureRandom)
+    {
+        /*
+         * Generate 48 random bytes we can use as a Pre-Master-Secret, if the PKCS1 padding check should fail.
+         */
+        byte[] fallback = new byte[48];
+        secureRandom.nextBytes(fallback);
+
+        byte[] M = Arrays.clone(fallback);
+        try
+        {
+            PKCS1Encoding encoding = new PKCS1Encoding(new RSABlindedEngine(), fallback);
+            encoding.init(false, new ParametersWithRandom(privateKey, secureRandom));
+
+            M = encoding.processBlock(encryptedPreMasterSecret, 0, encryptedPreMasterSecret.length);
+        }
+        catch (Exception e)
+        {
+            /*
+             * This should never happen since the decryption should never throw an exception and return a
+             * random value instead.
+             *
+             * In any case, a TLS server MUST NOT generate an alert if processing an RSA-encrypted premaster
+             * secret message fails, or the version number is not as expected. Instead, it MUST continue the
+             * handshake with a randomly generated premaster secret.
+             */
+        }
+
+        /*
+         * Compare the version number in the decrypted Pre-Master-Secret with the legacy_version field from
+         * the ClientHello. If they don't match, continue the handshake with the randomly generated 'fallback'
+         * value.
+         *
+         * NOTE: The comparison and replacement must be constant-time.
+         */
+        int mask = (Pack.bigEndianToShort(M, 0) ^ protocolVersion) & 0xFFFF;
+
+        // 'mask' will be all 1s if the versions matched, or else all 0s.
+        mask = (mask - 1) >> 31;
+
+        for (int i = 0; i < 48; i++)
+        {
+            M[i] = (byte)((M[i] & mask) | (fallback[i] & ~mask));
+        }
+
+        return M;
+    }
+}

--- a/core/src/test/java/org/bouncycastle/crypto/tls/TlsRsaKeyExchangeTest.java
+++ b/core/src/test/java/org/bouncycastle/crypto/tls/TlsRsaKeyExchangeTest.java
@@ -5,7 +5,6 @@ import org.bouncycastle.crypto.engines.RSABlindedEngine;
 import org.bouncycastle.crypto.encodings.PKCS1Encoding;
 import org.bouncycastle.crypto.params.ParametersWithRandom;
 import org.bouncycastle.crypto.params.RSAKeyParameters;
-import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.bouncycastle.util.test.SimpleTest;
 
 import java.security.SecureRandom;
@@ -20,7 +19,6 @@ public class TlsRsaKeyExchangeTest extends SimpleTest
 {
     public static void main(String[] args)
     {
-        Security.addProvider(new BouncyCastleProvider());
         runTest(new TlsRsaKeyExchangeTest());
     }
 

--- a/core/src/test/java/org/bouncycastle/crypto/tls/TlsRsaKeyExchangeTest.java
+++ b/core/src/test/java/org/bouncycastle/crypto/tls/TlsRsaKeyExchangeTest.java
@@ -1,0 +1,109 @@
+
+package org.bouncycastle.crypto.tls;
+
+import org.bouncycastle.crypto.engines.RSABlindedEngine;
+import org.bouncycastle.crypto.encodings.PKCS1Encoding;
+import org.bouncycastle.crypto.params.ParametersWithRandom;
+import org.bouncycastle.crypto.params.RSAKeyParameters;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.util.test.SimpleTest;
+
+import java.security.SecureRandom;
+import java.security.Security;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.interfaces.RSAPrivateKey;
+import java.security.interfaces.RSAPublicKey;
+import java.util.Arrays;
+
+public class TlsRsaKeyExchangeTest extends SimpleTest
+{
+    public static void main(String[] args)
+    {
+        Security.addProvider(new BouncyCastleProvider());
+        runTest(new TlsRsaKeyExchangeTest());
+    }
+
+    private SecureRandom secureRandom;
+    private RSAKeyParameters privateKey;
+    private RSAKeyParameters publicKey;
+    private int protocolVersion;
+
+    public TlsRsaKeyExchangeTest()
+    {
+        setUp();
+    }
+
+    public void setUp()
+    {
+        // Initialize objects
+        secureRandom = new SecureRandom();
+        KeyPair keyPair = generateRSAKeyPair();
+        privateKey = new RSAKeyParameters(
+                true,
+                ((RSAPrivateKey) keyPair.getPrivate()).getModulus(),
+                ((RSAPrivateKey) keyPair.getPrivate()).getPrivateExponent()
+        );
+        publicKey = new RSAKeyParameters(
+                false,
+                ((RSAPublicKey) keyPair.getPublic()).getModulus(),
+                ((RSAPublicKey) keyPair.getPublic()).getPublicExponent()
+        );
+        protocolVersion = 0x0303; // TLS 1.2
+    }
+
+    public void testDecryptPreMasterSecret()
+    {
+        byte[] preMasterSecret = new byte[48];
+        secureRandom.nextBytes(preMasterSecret);
+        preMasterSecret[0] = (byte) 0x03;
+        preMasterSecret[1] = (byte) 0x03; // TLS 1.2
+
+        // Encrypt the pre-master secret
+        byte[] encryptedPreMasterSecret = encryptPreMasterSecret(preMasterSecret);
+
+        // Decrypt and verify
+        byte[] result = TlsRsaKeyExchange.decryptPreMasterSecret(encryptedPreMasterSecret, privateKey, protocolVersion, secureRandom);
+
+        isTrue(Arrays.equals(preMasterSecret, result));
+    }
+
+    private byte[] encryptPreMasterSecret(byte[] preMasterSecret)
+    {
+        try
+        {
+            PKCS1Encoding encoding = new PKCS1Encoding(new RSABlindedEngine());
+            encoding.init(true, new ParametersWithRandom(publicKey, secureRandom));
+            return encoding.processBlock(preMasterSecret, 0, preMasterSecret.length);
+        } catch (Exception e)
+        {
+            throw new RuntimeException("Failed to encrypt pre-master secret", e);
+        }
+    }
+
+    private KeyPair generateRSAKeyPair()
+    {
+        try
+        {
+            KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("RSA");
+            keyPairGenerator.initialize(2048);
+            return keyPairGenerator.generateKeyPair();
+        } catch (Exception e)
+        {
+            throw new RuntimeException("Failed to generate RSA key pair", e);
+        }
+    }
+
+    @Override
+    public String getName()
+    {
+        return "TlsRsaKeyExchangeTest";
+    }
+
+    @Override
+    public void performTest() throws Exception
+    {
+        testDecryptPreMasterSecret();
+    }
+}
+

--- a/core/src/test/java/org/bouncycastle/crypto/tls/test/AllTests.java
+++ b/core/src/test/java/org/bouncycastle/crypto/tls/test/AllTests.java
@@ -1,0 +1,57 @@
+package org.bouncycastle.crypto.tls.test;
+
+import junit.extensions.TestSetup;
+import junit.framework.Test;
+import junit.framework.TestCase;
+import junit.framework.TestSuite;
+
+import org.bouncycastle.util.test.SimpleTestResult;
+
+
+public class AllTests
+    extends TestCase
+{
+    public void testCrypto() {
+
+        org.bouncycastle.util.test.Test[] tests = { new TlsRsaKeyExchangeTest()};
+        for(int i = 0; i != tests.length; i++)
+        {
+            SimpleTestResult result = (SimpleTestResult)tests[i].perform();
+
+            if (!result.isSuccessful())
+            {
+                fail(result.toString());
+            }
+        }
+    }
+    public static void main (String[] args)
+    {
+        junit.textui.TestRunner.run (suite());
+    }
+
+    public static Test suite()
+    {
+        TestSuite suite = new TestSuite("tls tests");
+        suite.addTestSuite(AllTests.class);
+        return new BCTestSetup(suite);
+    }
+
+    static class BCTestSetup
+        extends TestSetup
+    {
+        public BCTestSetup(Test test)
+        {
+            super(test);
+        }
+
+        protected void setUp()
+        {
+
+        }
+
+        protected void tearDown()
+        {
+
+        }
+    }
+}

--- a/core/src/test/java/org/bouncycastle/crypto/tls/test/TlsRsaKeyExchangeTest.java
+++ b/core/src/test/java/org/bouncycastle/crypto/tls/test/TlsRsaKeyExchangeTest.java
@@ -5,10 +5,7 @@ import org.bouncycastle.crypto.engines.RSABlindedEngine;
 import org.bouncycastle.crypto.encodings.PKCS1Encoding;
 import org.bouncycastle.crypto.params.ParametersWithRandom;
 import org.bouncycastle.crypto.params.RSAKeyParameters;
-<<<<<<< Updated upstream:core/src/test/java/org/bouncycastle/crypto/tls/TlsRsaKeyExchangeTest.java
-=======
 import org.bouncycastle.crypto.tls.TlsRsaKeyExchange;
->>>>>>> Stashed changes:core/src/test/java/org/bouncycastle/crypto/tls/test/TlsRsaKeyExchangeTest.java
 import org.bouncycastle.util.test.SimpleTest;
 
 import java.security.SecureRandom;

--- a/core/src/test/java/org/bouncycastle/crypto/tls/test/TlsRsaKeyExchangeTest.java
+++ b/core/src/test/java/org/bouncycastle/crypto/tls/test/TlsRsaKeyExchangeTest.java
@@ -1,14 +1,17 @@
 
-package org.bouncycastle.crypto.tls;
+package org.bouncycastle.crypto.tls.test;
 
 import org.bouncycastle.crypto.engines.RSABlindedEngine;
 import org.bouncycastle.crypto.encodings.PKCS1Encoding;
 import org.bouncycastle.crypto.params.ParametersWithRandom;
 import org.bouncycastle.crypto.params.RSAKeyParameters;
+<<<<<<< Updated upstream:core/src/test/java/org/bouncycastle/crypto/tls/TlsRsaKeyExchangeTest.java
+=======
+import org.bouncycastle.crypto.tls.TlsRsaKeyExchange;
+>>>>>>> Stashed changes:core/src/test/java/org/bouncycastle/crypto/tls/test/TlsRsaKeyExchangeTest.java
 import org.bouncycastle.util.test.SimpleTest;
 
 import java.security.SecureRandom;
-import java.security.Security;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.interfaces.RSAPrivateKey;

--- a/prov/src/main/java/org/bouncycastle/jcajce/provider/asymmetric/rsa/CustomPkcs1Encoding.java
+++ b/prov/src/main/java/org/bouncycastle/jcajce/provider/asymmetric/rsa/CustomPkcs1Encoding.java
@@ -1,4 +1,4 @@
-package org.bouncycastle.crypto.encodings;
+package org.bouncycastle.jcajce.provider.asymmetric.rsa;
 
 import java.security.SecureRandom;
 
@@ -6,6 +6,7 @@ import org.bouncycastle.crypto.AsymmetricBlockCipher;
 import org.bouncycastle.crypto.CipherParameters;
 import org.bouncycastle.crypto.CryptoServicesRegistrar;
 import org.bouncycastle.crypto.InvalidCipherTextException;
+import org.bouncycastle.crypto.encodings.PKCS1Encoding;
 import org.bouncycastle.crypto.params.AsymmetricKeyParameter;
 import org.bouncycastle.crypto.params.ParametersWithRandom;
 import org.bouncycastle.util.Arrays;
@@ -15,24 +16,9 @@ import org.bouncycastle.util.Properties;
  * this does your basic PKCS 1 v1.5 padding - whether or not you should be using this
  * depends on your application - see PKCS1 Version 2 for details.
  */
-public class PKCS1Encoding
+class CustomPKCS1Encoding
     implements AsymmetricBlockCipher
 {
-    /**
-     * @deprecated use NOT_STRICT_LENGTH_ENABLED_PROPERTY
-     */
-    public static final String STRICT_LENGTH_ENABLED_PROPERTY = "org.bouncycastle.pkcs1.strict";
-
-    /**
-     * some providers fail to include the leading zero in PKCS1 encoded blocks. If you need to
-     * work with one of these set the system property org.bouncycastle.pkcs1.not_strict to true.
-     * <p>
-     * The system property is checked during construction of the encoding object, it is set to
-     * false by default.
-     * </p>
-     */
-    public static final String NOT_STRICT_LENGTH_ENABLED_PROPERTY = "org.bouncycastle.pkcs1.not_strict";
-
     private static final int HEADER_LENGTH = 10;
 
     private SecureRandom random;
@@ -40,8 +26,6 @@ public class PKCS1Encoding
     private boolean forEncryption;
     private boolean forPrivateKey;
     private boolean useStrictLength;
-    private int pLen = -1;
-    private byte[] fallback = null;
     private byte[] blockBuffer;
 
     /**
@@ -49,57 +33,23 @@ public class PKCS1Encoding
      *
      * @param cipher
      */
-    public PKCS1Encoding(
-        AsymmetricBlockCipher cipher)
+    CustomPKCS1Encoding(AsymmetricBlockCipher cipher)
     {
         this.engine = cipher;
         this.useStrictLength = useStrict();
     }
-
-    /**
-     * Constructor for decryption with a fixed plaintext length.
-     *
-     * @param cipher The cipher to use for cryptographic operation.
-     * @param pLen   Length of the expected plaintext.
-     */
-    public PKCS1Encoding(
-        AsymmetricBlockCipher cipher,
-        int pLen)
-    {
-        this.engine = cipher;
-        this.useStrictLength = useStrict();
-        this.pLen = pLen;
-    }
-
-    /**
-     * Constructor for decryption with a fixed plaintext length and a fallback
-     * value that is returned, if the padding is incorrect.
-     *
-     * @param cipher   The cipher to use for cryptographic operation.
-     * @param fallback The fallback value, we don't do an arraycopy here.
-     */
-    public PKCS1Encoding(
-        AsymmetricBlockCipher cipher,
-        byte[] fallback)
-    {
-        this.engine = cipher;
-        this.useStrictLength = useStrict();
-        this.fallback = fallback;
-        this.pLen = fallback.length;
-    }
-
 
     //
     // for J2ME compatibility
     //
     private boolean useStrict()
     {
-        if (Properties.isOverrideSetTo(NOT_STRICT_LENGTH_ENABLED_PROPERTY, true))
+        if (Properties.isOverrideSetTo(PKCS1Encoding.NOT_STRICT_LENGTH_ENABLED_PROPERTY, true))
         {
             return false;
         }
 
-        return !Properties.isOverrideSetTo(STRICT_LENGTH_ENABLED_PROPERTY, false);
+        return !Properties.isOverrideSetTo(PKCS1Encoding.STRICT_LENGTH_ENABLED_PROPERTY, false);
     }
 
     public AsymmetricBlockCipher getUnderlyingCipher()
@@ -107,9 +57,7 @@ public class PKCS1Encoding
         return engine;
     }
 
-    public void init(
-        boolean forEncryption,
-        CipherParameters param)
+    public void init(boolean forEncryption, CipherParameters param)
     {
         AsymmetricKeyParameter kParam;
 
@@ -134,11 +82,6 @@ public class PKCS1Encoding
         this.forPrivateKey = kParam.isPrivate();
         this.forEncryption = forEncryption;
         this.blockBuffer = new byte[engine.getOutputBlockSize()];
-
-        if (pLen > 0 && fallback == null && random == null)
-        {
-           throw new IllegalArgumentException("encoder requires random");
-        }
     }
 
     public int getInputBlockSize()
@@ -169,11 +112,7 @@ public class PKCS1Encoding
         }
     }
 
-    public byte[] processBlock(
-        byte[] in,
-        int inOff,
-        int inLen)
-        throws InvalidCipherTextException
+    public byte[] processBlock(byte[] in, int inOff, int inLen) throws InvalidCipherTextException
     {
         if (forEncryption)
         {
@@ -185,11 +124,7 @@ public class PKCS1Encoding
         }
     }
 
-    private byte[] encodeBlock(
-        byte[] in,
-        int inOff,
-        int inLen)
-        throws InvalidCipherTextException
+    private byte[] encodeBlock(byte[] in, int inOff, int inLen) throws InvalidCipherTextException
     {
         if (inLen > getInputBlockSize())
         {
@@ -289,105 +224,11 @@ public class PKCS1Encoding
     }
 
     /**
-     * Check the argument is a valid encoding with type 2 of a plaintext with the given length. Returns 0 if
-     * valid, or -1 if invalid.
-     */
-    private static int checkPkcs1Encoding2(byte[] buf, int plaintextLength)
-    {
-        // The first byte should be 0x02
-        int badPadSign = -((buf[0] & 0xFF) ^ 0x02);
-
-        int lastPadPos = buf.length - 1 - plaintextLength;
-
-        // The header should be at least 10 bytes
-        badPadSign |= lastPadPos - 9;
-
-        // All pad bytes before the last one should be non-zero
-        for (int i = 1; i < lastPadPos; ++i)
-        {
-            badPadSign |= (buf[i] & 0xFF) - 1;
-        }
-
-        // Last pad byte should be zero
-        badPadSign |= -(buf[lastPadPos] & 0xFF);
-
-        return badPadSign >> 31;
-    }
-
-    /**
-     * Decode PKCS#1.5 encoding, and return a random value if the padding is not correct.
-     *
-     * @param in    The encrypted block.
-     * @param inOff Offset in the encrypted block.
-     * @param inLen Length of the encrypted block.
-     *              //@param pLen Length of the desired output.
-     * @return The plaintext without padding, or a random value if the padding was incorrect.
-     * @throws InvalidCipherTextException
-     */
-    private byte[] decodeBlockOrRandom(byte[] in, int inOff, int inLen)
-        throws InvalidCipherTextException
-    {
-        if (!forPrivateKey)
-        {
-            throw new InvalidCipherTextException("sorry, this method is only for decryption, not for signing");
-        }
-
-        int plaintextLength = this.pLen;
-
-        byte[] random = fallback;
-        if (fallback == null)
-        {
-            random = new byte[plaintextLength];
-            this.random.nextBytes(random);
-        }
-
-        int badPadMask = 0;
-        int strictBlockSize = engine.getOutputBlockSize();
-        byte[] block = engine.processBlock(in, inOff, inLen);
-
-        byte[] data = block;
-        if (block.length != strictBlockSize)
-        {
-            if (useStrictLength || block.length < strictBlockSize)
-            {
-                data = blockBuffer;
-            }
-        }
-
-        badPadMask |= checkPkcs1Encoding2(data, plaintextLength);
-
-        /*
-         * Now, to a constant time constant memory copy of the decrypted value
-         * or the random value, depending on the validity of the padding.
-         */
-        int dataOff = data.length - plaintextLength; 
-        byte[] result = new byte[plaintextLength];
-        for (int i = 0; i < plaintextLength; ++i)
-        {
-            result[i] = (byte)((data[dataOff + i] & ~badPadMask) | (random[i] & badPadMask));
-        }
-
-        Arrays.fill(block, (byte)0);
-        Arrays.fill(blockBuffer, 0, Math.max(0, blockBuffer.length - block.length), (byte)0);
-
-        return result;
-    }
-
-    /**
      * @throws InvalidCipherTextException if the decrypted block is not in PKCS1 format.
      */
     private byte[] decodeBlock(byte[] in, int inOff, int inLen)
         throws InvalidCipherTextException
     {
-        /*
-         * If the length of the expected plaintext is known, we use a constant-time decryption.
-         * If the decryption fails, we return a random value.
-         */
-        if (forPrivateKey && this.pLen != -1)
-        {
-            return this.decodeBlockOrRandom(in, inOff, inLen);
-        }
-
         int strictBlockSize = engine.getOutputBlockSize();
         byte[] block = engine.processBlock(in, inOff, inLen);
 
@@ -403,13 +244,10 @@ public class PKCS1Encoding
 
         try
         {
-            if (plaintextLength < 0)
+            if (plaintextLength < 0 | incorrectLength)
             {
-                throw new InvalidCipherTextException("block incorrect");
-            }
-            if (incorrectLength)
-            {
-                throw new InvalidCipherTextException("block incorrect size");
+                // Special behaviour to avoid throw/catch/throw in CipherSpi
+                return null;
             }
 
             byte[] result = new byte[plaintextLength];

--- a/prov/src/main/java/org/bouncycastle/jcajce/spec/TLSRSAPremasterSecretParameterSpec.java
+++ b/prov/src/main/java/org/bouncycastle/jcajce/spec/TLSRSAPremasterSecretParameterSpec.java
@@ -1,0 +1,19 @@
+package org.bouncycastle.jcajce.spec;
+
+import java.security.spec.AlgorithmParameterSpec;
+
+public class TLSRSAPremasterSecretParameterSpec
+    implements AlgorithmParameterSpec
+{
+    private final int protocolVersion;
+
+    public TLSRSAPremasterSecretParameterSpec(int protocolVersion)
+    {
+         this.protocolVersion = protocolVersion;
+    }
+
+    public int getProtocolVersion()
+    {
+        return protocolVersion;
+    }
+}

--- a/prov/src/test/java/org/bouncycastle/jcajce/provider/asymmetric/rsa/AllTests.java
+++ b/prov/src/test/java/org/bouncycastle/jcajce/provider/asymmetric/rsa/AllTests.java
@@ -1,0 +1,56 @@
+package org.bouncycastle.jcajce.provider.asymmetric.rsa;
+
+import junit.extensions.TestSetup;
+import junit.framework.Test;
+import junit.framework.TestCase;
+import junit.framework.TestSuite;
+import org.bouncycastle.util.test.SimpleTestResult;
+
+
+public class AllTests
+    extends TestCase
+{
+    public void testCustomPKCS1Encoding() {
+
+        org.bouncycastle.util.test.Test[] tests = { new CustomPKCS1EncodingTest()};
+        for(int i = 0; i != tests.length; i++)
+        {
+            SimpleTestResult result = (SimpleTestResult)tests[i].perform();
+
+            if (!result.isSuccessful())
+            {
+                fail(result.toString());
+            }
+        }
+    }
+    public static void main (String[] args)
+    {
+        junit.textui.TestRunner.run (suite());
+    }
+
+    public static Test suite()
+    {
+        TestSuite suite = new TestSuite("Custom PKCS1 Encoding tests");
+        suite.addTestSuite(AllTests.class);
+        return new BCTestSetup(suite);
+    }
+
+    static class BCTestSetup
+        extends TestSetup
+    {
+        public BCTestSetup(Test test)
+        {
+            super(test);
+        }
+
+        protected void setUp()
+        {
+
+        }
+
+        protected void tearDown()
+        {
+
+        }
+    }
+}

--- a/prov/src/test/java/org/bouncycastle/jcajce/provider/asymmetric/rsa/CustomPKCS1EncodingTest.java
+++ b/prov/src/test/java/org/bouncycastle/jcajce/provider/asymmetric/rsa/CustomPKCS1EncodingTest.java
@@ -1,0 +1,86 @@
+package org.bouncycastle.jcajce.provider.asymmetric.rsa;
+
+import org.bouncycastle.crypto.engines.RSABlindedEngine;
+import org.bouncycastle.crypto.params.ParametersWithRandom;
+import org.bouncycastle.crypto.params.RSAKeyParameters;
+import org.bouncycastle.crypto.tls.TlsRsaKeyExchange;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.util.test.SimpleTest;
+
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.SecureRandom;
+import java.security.Security;
+import java.security.interfaces.RSAPrivateKey;
+import java.security.interfaces.RSAPublicKey;
+import java.util.Arrays;
+
+public class CustomPKCS1EncodingTest extends SimpleTest
+{
+    static final int HEADER_LENGTH = 10;
+    SecureRandom secureRandom = new SecureRandom();
+    KeyPair keyPair = generateRSAKeyPair();
+    RSAKeyParameters privateKey = new RSAKeyParameters(
+                true,
+                        ((RSAPrivateKey) keyPair.getPrivate()).getModulus(),
+                ((RSAPrivateKey) keyPair.getPrivate()).getPrivateExponent()
+        );
+    RSAKeyParameters publicKey = new RSAKeyParameters(
+                false,
+                        ((RSAPublicKey) keyPair.getPublic()).getModulus(),
+                ((RSAPublicKey) keyPair.getPublic()).getPublicExponent()
+        );
+    RSABlindedEngine cipher = new RSABlindedEngine();
+    CustomPKCS1Encoding encode = new CustomPKCS1Encoding(cipher);
+    byte[] preMasterSecret = new byte[48];
+    int protocolVersion; // TLS 1.2
+
+    public static void main(String[] args) throws Exception
+    {
+        Security.addProvider(new BouncyCastleProvider());
+        runTest(new CustomPKCS1EncodingTest());
+    }
+    public void testCustomPKCS1Encoding() throws Exception
+    {
+        secureRandom.nextBytes(preMasterSecret);
+        preMasterSecret[0] = (byte) 0x03;
+        preMasterSecret[1] = (byte) 0x03; // TLS 1.2
+        protocolVersion = 0x0303; // TLS 1.2
+        encode.init(true, new ParametersWithRandom(publicKey, secureRandom));
+        byte[] encryptedPreMasterSecret = encode.processBlock(preMasterSecret, 0, preMasterSecret.length);
+        byte[] result = TlsRsaKeyExchange.decryptPreMasterSecret(encryptedPreMasterSecret, privateKey, protocolVersion, secureRandom);
+
+        isTrue(Arrays.equals(result, preMasterSecret));
+
+        isEquals(encode.getUnderlyingCipher(), cipher);
+
+        isEquals(encode.getInputBlockSize(), cipher.getInputBlockSize() - HEADER_LENGTH);
+
+        isEquals(encode.getOutputBlockSize(), cipher.getOutputBlockSize());
+    }
+
+    private KeyPair generateRSAKeyPair()
+    {
+        try
+        {
+            KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("RSA");
+            keyPairGenerator.initialize(2048);
+            return keyPairGenerator.generateKeyPair();
+        } catch (Exception e)
+        {
+            throw new RuntimeException("Failed to generate RSA key pair", e);
+        }
+    }
+
+    @Override
+    public String getName()
+    {
+        return "CustomPKCS1EncodingTest";
+    }
+
+    @Override
+    public void performTest() throws Exception
+    {
+        testCustomPKCS1Encoding();
+    }
+}

--- a/tls/src/main/java/org/bouncycastle/tls/crypto/impl/bc/BcDefaultTlsCredentialedDecryptor.java
+++ b/tls/src/main/java/org/bouncycastle/tls/crypto/impl/bc/BcDefaultTlsCredentialedDecryptor.java
@@ -1,20 +1,15 @@
 package org.bouncycastle.tls.crypto.impl.bc;
 
 import java.io.IOException;
-import java.security.SecureRandom;
 
-import org.bouncycastle.crypto.encodings.PKCS1Encoding;
-import org.bouncycastle.crypto.engines.RSABlindedEngine;
 import org.bouncycastle.crypto.params.AsymmetricKeyParameter;
-import org.bouncycastle.crypto.params.ParametersWithRandom;
 import org.bouncycastle.crypto.params.RSAKeyParameters;
+import org.bouncycastle.crypto.tls.TlsRsaKeyExchange;
 import org.bouncycastle.tls.Certificate;
 import org.bouncycastle.tls.ProtocolVersion;
 import org.bouncycastle.tls.TlsCredentialedDecryptor;
 import org.bouncycastle.tls.crypto.TlsCryptoParameters;
 import org.bouncycastle.tls.crypto.TlsSecret;
-import org.bouncycastle.tls.crypto.impl.TlsImplUtils;
-import org.bouncycastle.util.Arrays;
 
 /**
  * Credentialed class decrypting RSA encrypted secrets sent from a peer for our end of the TLS connection using the BC light-weight API.
@@ -27,7 +22,7 @@ public class BcDefaultTlsCredentialedDecryptor
     protected AsymmetricKeyParameter privateKey;
 
     public BcDefaultTlsCredentialedDecryptor(BcTlsCrypto crypto, Certificate certificate,
-                                           AsymmetricKeyParameter privateKey)
+            AsymmetricKeyParameter privateKey)
     {
         if (crypto == null)
         {
@@ -82,75 +77,10 @@ public class BcDefaultTlsCredentialedDecryptor
     protected TlsSecret safeDecryptPreMasterSecret(TlsCryptoParameters cryptoParams, RSAKeyParameters rsaServerPrivateKey,
                                                    byte[] encryptedPreMasterSecret)
     {
-        SecureRandom secureRandom = crypto.getSecureRandom();
-
-        /*
-         * RFC 5246 7.4.7.1.
-         */
         ProtocolVersion expectedVersion = cryptoParams.getRSAPreMasterSecretVersion();
 
-        // TODO Provide as configuration option?
-        boolean versionNumberCheckDisabled = false;
-
-        /*
-         * Generate 48 random bytes we can use as a Pre-Master-Secret, if the
-         * PKCS1 padding check should fail.
-         */
-        byte[] fallback = new byte[48];
-        secureRandom.nextBytes(fallback);
-
-        byte[] M = Arrays.clone(fallback);
-        try
-        {
-            PKCS1Encoding encoding = new PKCS1Encoding(new RSABlindedEngine(), fallback);
-            encoding.init(false, new ParametersWithRandom(rsaServerPrivateKey, secureRandom));
-
-            M = encoding.processBlock(encryptedPreMasterSecret, 0, encryptedPreMasterSecret.length);
-        }
-        catch (Exception e)
-        {
-            /*
-             * This should never happen since the decryption should never throw an exception
-             * and return a random value instead.
-             *
-             * In any case, a TLS server MUST NOT generate an alert if processing an
-             * RSA-encrypted premaster secret message fails, or the version number is not as
-             * expected. Instead, it MUST continue the handshake with a randomly generated
-             * premaster secret.
-             */
-        }
-
-        /*
-         * If ClientHello.legacy_version is TLS 1.1 or higher, server implementations MUST check the
-         * version number [..].
-         */
-        if (versionNumberCheckDisabled && !TlsImplUtils.isTLSv11(expectedVersion))
-        {
-            /*
-             * If the version number is TLS 1.0 or earlier, server implementations SHOULD check the
-             * version number, but MAY have a configuration option to disable the check.
-             */
-        }
-        else
-        {
-            /*
-             * Compare the version number in the decrypted Pre-Master-Secret with the legacy_version
-             * field from the ClientHello. If they don't match, continue the handshake with the
-             * randomly generated 'fallback' value.
-             *
-             * NOTE: The comparison and replacement must be constant-time.
-             */
-            int mask = (expectedVersion.getMajorVersion() ^ (M[0] & 0xFF))
-                     | (expectedVersion.getMinorVersion() ^ (M[1] & 0xFF));
-
-            // 'mask' will be all 1s if the versions matched, or else all 0s.
-            mask = (mask - 1) >> 31;
-
-            for (int i = 0; i < 48; i++)
-            {
-                M[i] = (byte)((M[i] & mask) | (fallback[i] & ~mask));
-            }
-        }
+        byte[] M = TlsRsaKeyExchange.decryptPreMasterSecret(encryptedPreMasterSecret, rsaServerPrivateKey,
+            expectedVersion.getFullVersion(), crypto.getSecureRandom());
 
         return crypto.createSecret(M);
     }

--- a/tls/src/main/java/org/bouncycastle/tls/crypto/impl/jcajce/JceDefaultTlsCredentialedDecryptor.java
+++ b/tls/src/main/java/org/bouncycastle/tls/crypto/impl/jcajce/JceDefaultTlsCredentialedDecryptor.java
@@ -7,12 +7,12 @@ import java.security.interfaces.RSAPrivateKey;
 
 import javax.crypto.Cipher;
 
+import org.bouncycastle.jcajce.spec.TLSRSAPremasterSecretParameterSpec;
 import org.bouncycastle.tls.Certificate;
 import org.bouncycastle.tls.ProtocolVersion;
 import org.bouncycastle.tls.TlsCredentialedDecryptor;
 import org.bouncycastle.tls.crypto.TlsCryptoParameters;
 import org.bouncycastle.tls.crypto.TlsSecret;
-import org.bouncycastle.tls.crypto.impl.TlsImplUtils;
 import org.bouncycastle.util.Arrays;
 
 /**
@@ -82,60 +82,55 @@ public class JceDefaultTlsCredentialedDecryptor
          * RFC 5246 7.4.7.1.
          */
         ProtocolVersion expectedVersion = cryptoParams.getRSAPreMasterSecretVersion();
+        byte[] M;
 
-        // TODO Provide as configuration option?
-        boolean versionNumberCheckDisabled = false;
-
-        /*
-         * Generate 48 random bytes we can use as a Pre-Master-Secret, if the
-         * PKCS1 padding check should fail.
-         */
-        byte[] fallback = new byte[48];
-        secureRandom.nextBytes(fallback);
-
-        byte[] M = Arrays.clone(fallback);
-        try
+       try
         {
             Cipher c = crypto.createRSAEncryptionCipher();
-            c.init(Cipher.DECRYPT_MODE, rsaServerPrivateKey, secureRandom);
-            byte[] m = c.doFinal(encryptedPreMasterSecret);
-            if (m != null && m.length == 48)
-            {
-                M = m;
-            }
-        }
-        catch (Exception e)
-        {
-            /*
-             * A TLS server MUST NOT generate an alert if processing an
-             * RSA-encrypted premaster secret message fails, or the version number is not as
-             * expected. Instead, it MUST continue the handshake with a randomly generated
-             * premaster secret.
-             */
-        }
 
-        /*
-         * If ClientHello.legacy_version is TLS 1.1 or higher, server implementations MUST check the
-         * version number [..].
-         */
-        if (versionNumberCheckDisabled && !TlsImplUtils.isTLSv11(expectedVersion))
-        {
-            /*
-             * If the version number is TLS 1.0 or earlier, server implementations SHOULD check the
-             * version number, but MAY have a configuration option to disable the check.
-             */
+            c.init(Cipher.DECRYPT_MODE, rsaServerPrivateKey, new TLSRSAPremasterSecretParameterSpec(expectedVersion.getFullVersion()), secureRandom);
+            M = c.doFinal(encryptedPreMasterSecret);
         }
-        else
+        catch (Exception ex)
         {
+            // Fallback
+
             /*
-             * Compare the version number in the decrypted Pre-Master-Secret with the legacy_version
-             * field from the ClientHello. If they don't match, continue the handshake with the
-             * randomly generated 'fallback' value.
+             * Generate 48 random bytes we can use as a Pre-Master-Secret, if the PKCS1 padding check should fail.
+             */
+            byte[] fallback = new byte[48];
+            secureRandom.nextBytes(fallback);
+
+            M = Arrays.clone(fallback);
+            try
+            {
+                Cipher c = crypto.createRSAEncryptionCipher();
+
+                c.init(Cipher.DECRYPT_MODE, rsaServerPrivateKey, secureRandom);
+                byte[] m = c.doFinal(encryptedPreMasterSecret);
+                if (m != null && m.length == 48)
+                {
+                    M = m;
+                }
+            }
+            catch (Exception e)
+            {
+                /*
+                 * A TLS server MUST NOT generate an alert if processing an RSA-encrypted premaster secret message
+                 * fails, or the version number is not as expected. Instead, it MUST continue the handshake with a
+                 * randomly generated premaster secret.
+                 */
+            }
+
+            /*
+             * Compare the version number in the decrypted Pre-Master-Secret with the legacy_version field from
+             * the ClientHello. If they don't match, continue the handshake with the randomly generated 'fallback'
+             * value.
              *
              * NOTE: The comparison and replacement must be constant-time.
              */
             int mask = (expectedVersion.getMajorVersion() ^ (M[0] & 0xFF))
-                     | (expectedVersion.getMinorVersion() ^ (M[1] & 0xFF));
+                | (expectedVersion.getMinorVersion() ^ (M[1] & 0xFF));
 
             // 'mask' will be all 1s if the versions matched, or else all 0s.
             mask = (mask - 1) >> 31;


### PR DESCRIPTION
original commits
1. d7d5e735abd64bf0f413f54fd9e495fc02400fb0 : added new RSA mode for better TLS unwrap operation
2. e0569dcb1dea9d421d84fc4c5c5688fe101afa2d : Improvements to PKCS1Encoding
3. d37128e62b282f61df663430e5a97a55de97302d : Factor out TlsRsaKeyExchange class into core