### PR TITLE
Update Lineaje version that ant build will use

### DIFF
--- a/bc-build.properties
+++ b/bc-build.properties
@@ -1,7 +1,7 @@
 
-release.suffix: 1.70.lineaje-b01
-release.name: 1.70.lineaje-b01
-release.version: 1.70.lineaje-b01
+release.suffix: 1.70.lineaje-01
+release.name: 1.70.lineaje-01
+release.version: 1.70.lineaje-01
 release.debug: false
 
 mail.jar.home: ./libs/mail.jar


### PR DESCRIPTION
Update Lineaje version as it contains fixes for CVE-2023-33201, CVE-2023-33202, and CVE-2024-29857